### PR TITLE
Add Freedesktop dbus Notification server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,108 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d26004fe83b2d1cd3a97609b21e39f9a31535822210fe83205d2ce48866ea61"
+dependencies = [
+ "event-listener",
+ "futures-core",
+ "parking_lot",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+dependencies = [
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
+name = "async-trait"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +126,30 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -69,13 +195,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix",
+ "nix 0.25.0",
  "winapi",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -94,6 +360,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +387,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "nasty"
 version = "0.1.0"
 dependencies = [
@@ -113,6 +440,20 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -128,16 +469,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "ordered-stream"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44630c059eacfd6e08bdaa51b1db2ce33119caa4ddc1235e923109aa5f25ccb1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polling"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -182,10 +615,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -219,6 +734,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,12 +817,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
+dependencies = [
+ "tempfile",
+ "winapi",
 ]
 
 [[package]]
@@ -255,6 +952,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "winapi"
@@ -286,3 +1004,135 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "zbus"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2db10dd0354816a3615c72deff837f983d5c8ad9a0312727d0f89a5a9e9145"
+dependencies = [
+ "async-broadcast",
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "byteorder",
+ "derivative",
+ "dirs",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.24.2",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03f1a5fb482cc0d97f3d3de9fe2e942f436a635a5fb6c12c9f03f21eb03075"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a408fd8a352695690f53906dc7fd036be924ec51ea5e05666ff42685ed0af5"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794fb7f59af4105697b0449ba31731ee5dbb3e773a17dbdf3d36206ea1b1644"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd58d4b6c8e26d3dd2149c8c40c6613ef6451b9885ff1296d1ac86c388351a54"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ clap = { version = "4.0.14", features = ["derive"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
+tokio = { version = "1.21.2", features = ["full"] }
+zbus = "3.2.0"

--- a/src/dnote/client.rs
+++ b/src/dnote/client.rs
@@ -1,10 +1,7 @@
-//! # DBus interface proxy for: `org.freedesktop.Notifications`
-
-use std::collections::HashMap;
-
 use zbus::dbus_proxy;
 use zbus::Connection;
 
+// DBus interface proxy for: `org.freedesktop.Notifications`
 #[dbus_proxy(interface = "org.freedesktop.Notifications")]
 trait Notifications {
     /// CloseNotification method

--- a/src/dnote/client.rs
+++ b/src/dnote/client.rs
@@ -62,3 +62,10 @@ pub async fn notify(
         .expect("");
     dbg!(reply);
 }
+
+pub async fn close_notification(id: u32) {
+    let connection = Connection::session().await.expect("");
+    let note = NotificationsProxy::new(&connection).await.expect("");
+    let reply = note.close_notification(id).await.expect("");
+    dbg!(reply);
+}

--- a/src/dnote/client.rs
+++ b/src/dnote/client.rs
@@ -36,19 +36,29 @@ trait Notifications {
 }
 
 pub async fn notify(
-        app_name: &str,
-        replaces_id: u32,
-        app_icon: &str,
-        summary: &str,
-        body: &str,
-        actions: &[&str],
-        hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
-        expire_timeout: i32,
-        ) {
+    app_name: &str,
+    replaces_id: u32,
+    app_icon: &str,
+    summary: &str,
+    body: &str,
+    actions: &[&str],
+    hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+    expire_timeout: i32,
+) {
     let connection = Connection::session().await.expect("");
     let note = NotificationsProxy::new(&connection).await.expect("");
-    let reply = note.notify(
-        app_name, replaces_id, app_icon, summary, body, actions, hints, expire_timeout
-    ).await.expect("");
+    let reply = note
+        .notify(
+            app_name,
+            replaces_id,
+            app_icon,
+            summary,
+            body,
+            actions,
+            hints,
+            expire_timeout,
+        )
+        .await
+        .expect("");
     dbg!(reply);
 }

--- a/src/dnote/client.rs
+++ b/src/dnote/client.rs
@@ -1,0 +1,57 @@
+//! # DBus interface proxy for: `org.freedesktop.Notifications`
+
+use std::collections::HashMap;
+
+use zbus::dbus_proxy;
+use zbus::Connection;
+
+#[dbus_proxy(interface = "org.freedesktop.Notifications")]
+trait Notifications {
+    /// CloseNotification method
+    fn close_notification(&self, id: u32) -> zbus::Result<()>;
+
+    /// GetCapabilities method
+    fn get_capabilities(&self) -> zbus::Result<Vec<String>>;
+
+    /// GetServerInformation method
+    fn get_server_information(&self) -> zbus::Result<(String, String, String, String)>;
+
+    /// Notify method
+    fn notify(
+        &self,
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: &[&str],
+        hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+        expire_timeout: i32,
+    ) -> zbus::Result<u32>;
+
+    /// ActionInvoked signal
+    #[dbus_proxy(signal)]
+    fn action_invoked(&self, id: u32, action_key: &str) -> zbus::Result<()>;
+
+    /// NotificationClosed signal
+    #[dbus_proxy(signal)]
+    fn notification_closed(&self, id: u32, reason: u32) -> zbus::Result<()>;
+}
+
+pub async fn notify(
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: &[&str],
+        hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+        expire_timeout: i32,
+        ) {
+    let connection = Connection::session().await.expect("");
+    let note = NotificationsProxy::new(&connection).await.expect("");
+    let reply = note.notify(
+        app_name, replaces_id, app_icon, summary, body, actions, hints, expire_timeout
+    ).await.expect("");
+    dbg!(reply);
+}

--- a/src/dnote/mod.rs
+++ b/src/dnote/mod.rs
@@ -1,0 +1,2 @@
+pub mod server;
+pub mod client;

--- a/src/dnote/mod.rs
+++ b/src/dnote/mod.rs
@@ -1,2 +1,2 @@
-pub mod server;
 pub mod client;
+pub mod server;

--- a/src/dnote/server.rs
+++ b/src/dnote/server.rs
@@ -1,0 +1,87 @@
+use zbus::{dbus_interface, Connection};
+
+struct Notes;
+
+#[dbus_interface(name = "org.freedesktop.Notifications")]
+impl Notes {
+    async fn say_hello(&self, name: &str) -> String {
+        format!("Hello {}!", name)
+    }
+    // CloseNotification method
+    //async fn close_notification(&self, id: u32) -> zbus::Result<()>;
+
+    // GetCapabilities method
+    async fn get_capabilities(&self) -> zbus::fdo::Result<Vec<String>> {
+        // uncomment lines as they're implemented
+        Ok(Vec::from([
+            // String::from("actions-icons"),
+            // String::from("actions"),
+            String::from("body"),
+            // String::from("body-hyperlinks"),
+            // String::from("body-markup"),
+            // String::from("icon-multi"),
+            // String::from("icon-static"),
+            // String::from("persistence"),
+            // String::from("sound"),
+        ]))
+    }
+
+    // GetServerInformation method
+    #[dbus_interface(out_args("name", "vendor", "version", "spec_version"))]
+    async fn get_server_information(&self) -> zbus::fdo::Result<(&str, &str, &str, &str)> {
+        return Ok(("dnote", "kgb33", "v0.0.0", "1.2"));
+    } 
+
+    // Notify method
+    async fn notify(
+      &self,
+      app_name: &str,
+      replaces_id: u32,
+      app_icon: &str,
+      summary: &str,
+      body: &str,
+      actions: Vec<&str>,
+      hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+      expire_timeout: i32,
+    ) -> u32 {
+        println!("notify called:
+                 app_name: {app_name} 
+                 replaces_id: {replaces_id}
+                 app_icon: {app_icon}
+                 summary: {summary}
+                 body: {body}
+                 actions: {actions:?}
+                 hints: {hints:?}
+                 expire_timeout: {expire_timeout}
+                 ");
+        return replaces_id; 
+    }
+
+    // ActionInvoked signal
+    //#[dbus_proxy(signal)]
+    //fn action_invoked(&self, id: u32, action_key: &str) -> zbus::Result<()>;
+
+    // NotificationClosed signal
+    //#[dbus_proxy(signal)]
+    //fn notification_closed(&self, id: u32, reason: u32) -> zbus::Result<()>;
+
+}
+
+pub async fn serve() {
+    let connection = Connection::session().await.expect("");
+    // setup the server
+    connection
+        .object_server()
+        .at("/org/freedesktop/Notifications", Notes)
+        .await.expect("");
+    // before requesting the name
+    connection
+        .request_name("org.freedesktop.Notifications")
+        .await.expect("");
+
+    loop {
+        // do something else, wait forever or timeout here:
+        // handling D-Bus messages is done in the background
+        std::future::pending::<()>().await;
+    }
+}

--- a/src/dnote/server.rs
+++ b/src/dnote/server.rs
@@ -43,11 +43,13 @@ struct Notes {
 
 impl Notes {
     fn new() -> Notes {
-        Notes {
+        let mut n = Notes {
             notifications: HashMap::new(),
             priority: Vec::new(),
             last_id: 1,
-        }
+        };
+        n.on_change();
+        return n;
     }
     fn next_id(&mut self) -> u32 {
         self.last_id += 1;

--- a/src/dnote/server.rs
+++ b/src/dnote/server.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use zbus::{
-    dbus_interface, dbus_proxy,
+    dbus_interface,
     zvariant::{DeserializeDict, SerializeDict, Type},
     Connection,
 };
@@ -74,6 +74,7 @@ impl Notes {
     // CloseNotification method
     async fn close_notification(&mut self, id: u32) {
         self.notifications.remove_entry(&id);
+        self.on_change();
     }
 
     // GetCapabilities method
@@ -108,7 +109,7 @@ impl Notes {
         body: String,
         actions: Vec<String>,
         hints: Hints,
-        expire_timeout: i32,
+        _expire_timeout: i32, // TODO
     ) -> u32 {
         let mut replaces_id = replaces_id;
         if replaces_id == 0 {
@@ -136,6 +137,7 @@ impl Notes {
     // NotificationClosed signal
     async fn notification_closed(&mut self, id: u32, _reason: u32) {
         self.notifications.remove(&id);
+        self.on_change();
     }
 }
 

--- a/src/dnote/server.rs
+++ b/src/dnote/server.rs
@@ -30,21 +30,22 @@ impl Notes {
     #[dbus_interface(out_args("name", "vendor", "version", "spec_version"))]
     async fn get_server_information(&self) -> zbus::fdo::Result<(&str, &str, &str, &str)> {
         return Ok(("dnote", "kgb33", "v0.0.0", "1.2"));
-    } 
+    }
 
     // Notify method
     async fn notify(
-      &self,
-      app_name: &str,
-      replaces_id: u32,
-      app_icon: &str,
-      summary: &str,
-      body: &str,
-      actions: Vec<&str>,
-      hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
-      expire_timeout: i32,
+        &self,
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: Vec<&str>,
+        hints: std::collections::HashMap<&str, zbus::zvariant::Value<'_>>,
+        expire_timeout: i32,
     ) -> u32 {
-        println!("notify called:
+        println!(
+            "notify called:
                  app_name: {app_name} 
                  replaces_id: {replaces_id}
                  app_icon: {app_icon}
@@ -53,8 +54,9 @@ impl Notes {
                  actions: {actions:?}
                  hints: {hints:?}
                  expire_timeout: {expire_timeout}
-                 ");
-        return replaces_id; 
+                 "
+        );
+        return replaces_id;
     }
 
     // ActionInvoked signal
@@ -64,7 +66,6 @@ impl Notes {
     // NotificationClosed signal
     //#[dbus_proxy(signal)]
     //fn notification_closed(&self, id: u32, reason: u32) -> zbus::Result<()>;
-
 }
 
 pub async fn serve() {
@@ -73,11 +74,13 @@ pub async fn serve() {
     connection
         .object_server()
         .at("/org/freedesktop/Notifications", Notes)
-        .await.expect("");
+        .await
+        .expect("");
     // before requesting the name
     connection
         .request_name("org.freedesktop.Notifications")
-        .await.expect("");
+        .await
+        .expect("");
 
     loop {
         // do something else, wait forever or timeout here:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-pub mod workspaces;
-pub mod notifications;
 pub mod dnote;
+pub mod notifications;
+pub mod workspaces;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod workspaces;
+pub mod notifications;
+pub mod dnote;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ enum WindowManagers {
 fn main() {
     let args = Cli::parse();
     match args.command {
-        Commands::Notification {} => notifications::send_test_note(),
+        //Commands::Notification {} => notifications::send_test_note(),
+        Commands::Notification {} => notifications::start_server(),
         Commands::Workspaces { wm } => match wm {
             WindowManagers::Hyperland => workspaces::hyperland_wm(),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-use clap::{Parser, Subcommand, ValueEnum};
+extern crate nasty;
 
-mod workspaces;
+use clap::{Parser, Subcommand, ValueEnum};
+use nasty::{notifications, workspaces};
 
 /// A listener cli designed to be used with EWW widgets.
-#[derive(Debug, Parser)] 
+#[derive(Debug, Parser)]
 #[command(name = "nasty")]
 struct Cli {
     #[command(subcommand)]
@@ -15,9 +16,6 @@ enum Commands {
     /// Listens on the org.freedesktop.Notifications Dbus
     #[command()]
     Notification {
-        /// The bus to connect to.
-        #[arg(default_value="org.freedesktop.Notifications")]
-        bus: String,
     },
     /// Listens to workspace changes
     #[command()]
@@ -36,7 +34,9 @@ enum WindowManagers {
 fn main() {
     let args = Cli::parse();
     match args.command {
-        Commands::Notification { bus } => println!("Notifications WIP! {bus}"),
-        Commands::Workspaces { wm } => match wm {WindowManagers::Hyperland => workspaces::hyperland_wm()},
-    } 
+        Commands::Notification {} => notifications::send_test_note(),
+        Commands::Workspaces { wm } => match wm {
+            WindowManagers::Hyperland => workspaces::hyperland_wm(),
+        },
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
         //Commands::Notification {} => notifications::send_test_note(),
         Commands::Notifications { server, close } => match (server, close) {
             (true, _) => notifications::start_server(),
+            (false, 0) => println!("Unknown usage, see -h."),
             (false, close) => notifications::close_notification(close),
         },
         Commands::Workspaces { wm } => match wm {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,13 @@ struct Cli {
 enum Commands {
     /// Listens on the org.freedesktop.Notifications Dbus
     #[command()]
-    Notification {},
+    Notifications {
+        #[arg(short, long, default_value_t = false)]
+        server: bool,
+        #[arg(short, long, default_value_t = 0)]
+        close: u32,
+    },
+
     /// Listens to workspace changes
     #[command()]
     Workspaces {
@@ -34,7 +40,10 @@ fn main() {
     let args = Cli::parse();
     match args.command {
         //Commands::Notification {} => notifications::send_test_note(),
-        Commands::Notification {} => notifications::start_server(),
+        Commands::Notifications { server, close } => match (server, close) {
+            (true, _) => notifications::start_server(),
+            (false, close) => notifications::close_notification(close),
+        },
         Commands::Workspaces { wm } => match wm {
             WindowManagers::Hyperland => workspaces::hyperland_wm(),
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,7 @@ struct Cli {
 enum Commands {
     /// Listens on the org.freedesktop.Notifications Dbus
     #[command()]
-    Notification {
-    },
+    Notification {},
     /// Listens to workspace changes
     #[command()]
     Workspaces {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use tokio;
 
 use crate::dnote::client::notify;
+use crate::dnote::server::serve;
 
 pub fn send_test_note() {
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -15,5 +16,10 @@ pub fn send_test_note() {
         HashMap::new(),
         5000,
         );
+    rt.block_on(future);
+}
+pub fn start_server() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let future = serve();
     rt.block_on(future);
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -2,12 +2,11 @@ use std::collections::HashMap;
 
 use tokio;
 
-use crate::dnote::client::notify;
-use crate::dnote::server::serve;
+use crate::dnote::{client, server};
 
 pub fn send_test_note() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let future = notify(
+    let future = client::notify(
         "nasty",
         0,
         "an icon",
@@ -19,8 +18,15 @@ pub fn send_test_note() {
     );
     rt.block_on(future);
 }
+
+pub fn close_notification(id: u32) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let future = client::close_notification(id);
+    rt.block_on(future);
+}
+
 pub fn start_server() {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let future = serve();
+    let future = server::serve();
     rt.block_on(future);
 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -11,11 +11,12 @@ pub fn send_test_note() {
         "nasty",
         0,
         "an icon",
-        "A Test", "This is a test notification from nasty.",
+        "A Test",
+        "This is a test notification from nasty.",
         &[],
         HashMap::new(),
         5000,
-        );
+    );
     rt.block_on(future);
 }
 pub fn start_server() {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+use tokio;
+
+use crate::dnote::client::notify;
+
+pub fn send_test_note() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let future = notify(
+        "nasty",
+        0,
+        "an icon",
+        "A Test", "This is a test notification from nasty.",
+        &[],
+        HashMap::new(),
+        5000,
+        );
+    rt.block_on(future);
+}

--- a/src/workspaces.rs
+++ b/src/workspaces.rs
@@ -1,13 +1,12 @@
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::io::BufRead;
 use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
 use std::process;
 use std::{env, io::BufReader};
-use std::io::BufRead;
-use std::os::unix::net::UnixStream;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug)]
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct WorkspaceState {
     active_workspace: u8,
     wss: BTreeMap<u8, String>,
@@ -17,19 +16,19 @@ struct WorkspaceState {
 #[derive(Serialize, Deserialize)]
 struct WorkspaceJson {
     id: u8,
-    lastwindowtitle: String
-} 
+    lastwindowtitle: String,
+}
 
 #[derive(Serialize, Deserialize)]
 struct InnerActiveWindow {
-    id: u8
+    id: u8,
 }
 
 #[derive(Serialize, Deserialize)]
 struct ActiveWindow {
     workspace: InnerActiveWindow,
-    title: String
-} 
+    title: String,
+}
 
 impl WorkspaceState {
     fn new() -> WorkspaceState {
@@ -39,8 +38,8 @@ impl WorkspaceState {
             .arg("workspaces")
             .output()
             .expect("Couldn't get current ws setup");
-        let data: Vec<WorkspaceJson> = serde_json::from_slice(&data.stdout)
-            .expect("Err converting to json.");
+        let data: Vec<WorkspaceJson> =
+            serde_json::from_slice(&data.stdout).expect("Err converting to json.");
         let mut map = BTreeMap::new();
         for ws in data {
             map.insert(ws.id, ws.lastwindowtitle);
@@ -53,55 +52,64 @@ impl WorkspaceState {
             .expect("Couldn't get current active window.");
         let data: ActiveWindow = match serde_json::from_slice(&data.stdout) {
             Ok(value) => value,
-            Err(_) => ActiveWindow { workspace: InnerActiveWindow { id: 1 }, title: String::from("eww loading...") }
+            Err(_) => ActiveWindow {
+                workspace: InnerActiveWindow { id: 1 },
+                title: String::from("eww loading..."),
+            },
         };
-        WorkspaceState { active_workspace: data.workspace.id, wss: map.to_owned(), ws_names: map.into_keys().collect()}
+        WorkspaceState {
+            active_workspace: data.workspace.id,
+            wss: map.to_owned(),
+            ws_names: map.into_keys().collect(),
+        }
     }
 
-    fn update(&mut self, opcode: String, value: String) -> bool{
+    fn update(&mut self, opcode: String, value: String) -> bool {
         match opcode.as_str() {
             "workspace" => {
-                self.active_workspace = u8::from_str_radix(&value, 10).expect("err converting to int.");
+                self.active_workspace =
+                    u8::from_str_radix(&value, 10).expect("err converting to int.");
                 return true;
-            },
+            }
             "createworkspace" => {
                 let value = u8::from_str_radix(&value, 10).expect("err converting to int.");
                 self.wss.insert(value, String::new());
                 self.ws_names = self.wss.to_owned().into_keys().collect();
                 return true;
-            },
+            }
             "destroyworkspace" => {
                 let value = u8::from_str_radix(&value, 10).expect("err converting to int.");
                 self.wss.remove(&value);
                 self.ws_names = self.wss.to_owned().into_keys().collect();
                 return true;
-            },
+            }
             "activewindow" => {
-                if value != "," { 
+                if value != "," {
                     let value = value.split(",").collect::<Vec<_>>();
                     self.wss.insert(self.active_workspace, value[1].to_string());
                     return true;
                 }
                 return false;
-            },
+            }
             _ => {
                 return false;
-            },
+            }
         }
     }
-    
 }
 pub fn hyperland_wm() {
     let hypr_id = env::var("HYPRLAND_INSTANCE_SIGNATURE").expect("Is Hyperland running?");
-    let addr = format!("/tmp/hypr/{hypr_id}/.socket2.sock"); 
+    let addr = format!("/tmp/hypr/{hypr_id}/.socket2.sock");
     let mut state = WorkspaceState::new();
-    let u_stream = UnixStream::connect(addr)
-                       .expect("Couldn't connect to the server...");
+    let u_stream = UnixStream::connect(addr).expect("Couldn't connect to the server...");
     let stream = BufReader::new(u_stream.try_clone().expect("Couldn't clone socket"));
-    ctrlc::set_handler(move ||{
-        u_stream.shutdown(Shutdown::Read).expect("shutdown function failed");
+    ctrlc::set_handler(move || {
+        u_stream
+            .shutdown(Shutdown::Read)
+            .expect("shutdown function failed");
         println!("Closing socket reader.")
-    }).expect("Error setting Ctrl-C handler");
+    })
+    .expect("Error setting Ctrl-C handler");
     for line in stream.lines() {
         let line = line.expect("");
         let line = line.split(">>").collect::<Vec<_>>();


### PR DESCRIPTION
Implements a minimal `org.freedesktop.Notifications` dbus client/server based off of `v1.2` of [this spec](https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html). 

At some point the `dnote` sub-crate should be refactored into a stand-alone package. 