### PR TITLE
feat: Add Sway Workspaces support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "swayipc",
  "tokio",
  "zbus",
 ]
@@ -1439,6 +1440,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
+name = "swayipc"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa5d19f881f372e225095e297072e2e3ee1c4e9e3a46cafe5f5cf70f1313f29"
+dependencies = [
+ "serde",
+ "serde_json",
+ "swayipc-types",
+]
+
+[[package]]
+name = "swayipc-types"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e487a656336f74341c70a73a289f68d9ba3cab579ba776352ea0c6cdf603fcda"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1520,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ ctrlc = { version = "3.0", features = ["termination"] }
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
+swayipc = "3.0.2"
 tokio = { version = "1.36.0", features = ["full"] }
 zbus = "4.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ enum Commands {
     #[command()]
     Workspaces {
         /// The WM being used.
-        #[arg(default_value_t=WindowManagers::Hyperland, value_enum)]
+        #[arg(default_value_t=WindowManagers::Hyprland, value_enum)]
         wm: WindowManagers,
     },
 
@@ -62,7 +62,7 @@ fn main() {
             (false, close) => notifications::close_notification(close),
         },
         Commands::Workspaces { wm } => match wm {
-            WindowManagers::Hyperland => workspaces::hyprland::listen_and_print(),
+            WindowManagers::Hyprland => workspaces::hyprland::listen_and_print(),
             WindowManagers::Sway => workspaces::sway::listen_and_print(),
         },
         Commands::Updates { pkg, lock_file } => match pkg {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,8 @@ enum Commands {
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
 enum WindowManagers {
-    Hyperland,
+    Hyprland,
+    Sway,
 }
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
@@ -61,7 +62,8 @@ fn main() {
             (false, close) => notifications::close_notification(close),
         },
         Commands::Workspaces { wm } => match wm {
-            WindowManagers::Hyperland => workspaces::hyperland_wm(),
+            WindowManagers::Hyperland => workspaces::hyprland::listen_and_print(),
+            WindowManagers::Sway => workspaces::sway::listen_and_print(),
         },
         Commands::Updates { pkg, lock_file } => match pkg {
             PackageManagers::Nix => upgrade::nixos(&lock_file),

--- a/src/workspaces/hyprland.rs
+++ b/src/workspaces/hyprland.rs
@@ -95,7 +95,7 @@ impl WorkspaceState {
     }
 }
 pub fn listen_and_print() {
-    let hypr_id = env::var("HYPRLAND_INSTANCE_SIGNATURE").expect("Is Hyperland running?");
+    let hypr_id = env::var("HYPRLAND_INSTANCE_SIGNATURE").expect("Is Hyprland running?");
     let addr = format!("/tmp/hypr/{hypr_id}/.socket2.sock");
     let mut state = WorkspaceState::new();
     let u_stream = UnixStream::connect(addr).expect("Couldn't connect to the server...");

--- a/src/workspaces/hyprland.rs
+++ b/src/workspaces/hyprland.rs
@@ -1,103 +1,42 @@
-use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+
 use std::io::BufRead;
 use std::net::Shutdown;
 use std::os::unix::net::UnixStream;
-use std::process;
 use std::{env, io::BufReader};
 
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkspaceState {
-    active_workspace: u8,
-    wss: BTreeMap<u8, String>,
-    ws_names: Vec<u8>,
-}
+use super::internal::{WorkspaceChange, WorkspaceState};
 
-#[derive(Serialize, Deserialize)]
-struct WorkspaceJson {
-    id: u8,
-    lastwindowtitle: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct InnerActiveWindow {
-    id: u8,
-}
-
-#[derive(Serialize, Deserialize)]
-struct ActiveWindow {
-    workspace: InnerActiveWindow,
-    title: String,
-}
-
-impl WorkspaceState {
-    fn new() -> WorkspaceState {
-        // Generate current workspaces
-        let data = process::Command::new("hyprctl")
-            .arg("-j")
-            .arg("workspaces")
-            .output()
-            .expect("Couldn't get current ws setup");
-        let data: Vec<WorkspaceJson> =
-            serde_json::from_slice(&data.stdout).expect("Err converting to json.");
-        let mut map = BTreeMap::new();
-        for ws in data {
-            map.insert(ws.id, ws.lastwindowtitle);
-        }
-        // Determine active workspace
-        let data = process::Command::new("hyprctl")
-            .arg("-j")
-            .arg("activewindow")
-            .output()
-            .expect("Couldn't get current active window.");
-        let data: ActiveWindow = match serde_json::from_slice(&data.stdout) {
-            Ok(value) => value,
-            Err(_) => ActiveWindow {
-                workspace: InnerActiveWindow { id: 1 },
-                title: String::from("eww loading..."),
-            },
+fn _listen_and_print(stream: BufReader<UnixStream>) {
+    let mut state = WorkspaceState::new();
+    for line in stream.lines() {
+        let Ok(msg) = line else {
+            continue;
         };
-        WorkspaceState {
-            active_workspace: data.workspace.id,
-            wss: map.to_owned(),
-            ws_names: map.into_keys().collect(),
-        }
-    }
-
-    fn update(&mut self, opcode: String, value: String) -> bool {
-        match opcode.as_str() {
+        let content = msg.split(">>").collect::<Vec<_>>();
+        let [opcode, id, _] = content[..] else {
+            continue;
+        };
+        let id = id.parse::<i64>().unwrap_or(0);
+        match opcode {
             "workspace" => {
-                self.active_workspace = value.parse().expect("err converting to int.");
-                true
+                state.update(WorkspaceChange::Focus(id));
             }
             "createworkspace" => {
-                let value = value.parse::<u8>().expect("err converting to int.");
-                self.wss.insert(value, String::new());
-                self.ws_names = self.wss.to_owned().into_keys().collect();
-                true
+                state.update(WorkspaceChange::Create(id));
             }
             "destroyworkspace" => {
-                let value = value.parse::<u8>().expect("err converting to int.");
-                self.wss.remove(&value);
-                self.ws_names = self.wss.to_owned().into_keys().collect();
-                true
+                state.update(WorkspaceChange::Destroy(id));
             }
-            "activewindow" => {
-                if value != "," {
-                    let value = value.split(',').collect::<Vec<_>>();
-                    self.wss.insert(self.active_workspace, value[1].to_string());
-                    return true;
-                }
-                false
-            }
-            _ => false,
+            _ => continue,
+        }
+        if let Ok(data) = serde_json::to_string(&state) {
+            println!("{}", data);
         }
     }
 }
 pub fn listen_and_print() {
     let hypr_id = env::var("HYPRLAND_INSTANCE_SIGNATURE").expect("Is Hyprland running?");
     let addr = format!("/tmp/hypr/{hypr_id}/.socket2.sock");
-    let mut state = WorkspaceState::new();
     let u_stream = UnixStream::connect(addr).expect("Couldn't connect to the server...");
     let stream = BufReader::new(u_stream.try_clone().expect("Couldn't clone socket"));
     ctrlc::set_handler(move || {
@@ -107,12 +46,5 @@ pub fn listen_and_print() {
         println!("Closing socket reader.")
     })
     .expect("Error setting Ctrl-C handler");
-    for line in stream.lines() {
-        let line = line.expect("");
-        let line = line.split(">>").collect::<Vec<_>>();
-        if state.update(line[0].to_string(), line[1].to_string()) {
-            let out = serde_json::to_string(&state).expect("");
-            println!("{}", out);
-        }
-    }
+    _listen_and_print(stream);
 }

--- a/src/workspaces/hyprland.rs
+++ b/src/workspaces/hyprland.rs
@@ -94,7 +94,7 @@ impl WorkspaceState {
         }
     }
 }
-pub fn hyperland_wm() {
+pub fn listen_and_print() {
     let hypr_id = env::var("HYPRLAND_INSTANCE_SIGNATURE").expect("Is Hyperland running?");
     let addr = format!("/tmp/hypr/{hypr_id}/.socket2.sock");
     let mut state = WorkspaceState::new();

--- a/src/workspaces/internal.rs
+++ b/src/workspaces/internal.rs
@@ -1,0 +1,44 @@
+// Internal, standarized, representation of multiple
+// Window managers' workspaces.
+
+use std::{collections::BTreeSet};
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct WorkspaceState {
+    active_workspace: i64,
+    workspaces: BTreeSet<i64>,
+}
+
+pub enum WorkspaceChange {
+    Destroy(i64),
+    Create(i64),
+    Focus(i64),
+}
+
+impl Default for WorkspaceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkspaceState {
+    pub fn new() -> WorkspaceState {
+        WorkspaceState {
+            active_workspace: 0,
+            workspaces: BTreeSet::new(),
+        }
+    }
+    pub fn update(&mut self, optcode: WorkspaceChange) -> bool {
+        match optcode {
+            WorkspaceChange::Create(id) => self.workspaces.insert(id),
+            WorkspaceChange::Destroy(id) => self.workspaces.remove(&id),
+            WorkspaceChange::Focus(id) => {
+                self.active_workspace = id;
+                // Adds the workspaces when they exist before this program starts
+                !self.workspaces.insert(id)
+            }
+        }
+    }
+}

--- a/src/workspaces/internal.rs
+++ b/src/workspaces/internal.rs
@@ -1,7 +1,7 @@
 // Internal, standarized, representation of multiple
 // Window managers' workspaces.
 
-use std::{collections::BTreeSet};
+use std::collections::BTreeSet;
 
 use serde::Serialize;
 

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1,0 +1,2 @@
+pub mod hyprland;
+pub mod sway;

--- a/src/workspaces/mod.rs
+++ b/src/workspaces/mod.rs
@@ -1,2 +1,3 @@
 pub mod hyprland;
+pub mod internal;
 pub mod sway;

--- a/src/workspaces/sway.rs
+++ b/src/workspaces/sway.rs
@@ -1,0 +1,4 @@
+pub fn listen_and_print() {
+    println!("Call'n sway workspaces!");
+    todo!();
+}

--- a/src/workspaces/sway.rs
+++ b/src/workspaces/sway.rs
@@ -1,4 +1,19 @@
+use swayipc::{Connection, EventType, Fallible};
+
+fn _listen_and_print() -> Fallible<()> {
+    let subs = [EventType::Workspace];
+    for event in Connection::new()?.subscribe(subs)? {
+        let ws = match event? {
+            swayipc::Event::Workspace(ws) => ws,
+            _ => continue, // We're only listening for Workspace events
+        };
+        println!("{:?}", *ws)
+    }
+    Ok(())
+}
 pub fn listen_and_print() {
-    println!("Call'n sway workspaces!");
-    todo!();
+    match _listen_and_print() {
+        Ok(_) => return,
+        Err(e) => panic!("{}", e),
+    }
 }

--- a/src/workspaces/sway.rs
+++ b/src/workspaces/sway.rs
@@ -1,19 +1,44 @@
 use swayipc::{Connection, EventType, Fallible};
 
+use crate::workspaces::internal::{WorkspaceChange, WorkspaceState};
+
 fn _listen_and_print() -> Fallible<()> {
     let subs = [EventType::Workspace];
+    let mut state = WorkspaceState::new();
     for event in Connection::new()?.subscribe(subs)? {
-        let ws = match event? {
-            swayipc::Event::Workspace(ws) => ws,
-            _ => continue, // We're only listening for Workspace events
+        let swayipc::Event::Workspace(ws) = event? else {
+            continue;
         };
-        println!("{:?}", *ws)
+        let Some(node) = ws.current else {
+            eprintln!("Got a {:?} event with no workspace...?", ws.change);
+            continue;
+        };
+        let id = node
+            .name
+            .map_or(node.id, |v| v.as_str().parse::<i64>().unwrap_or(node.id));
+        match ws.change {
+            swayipc::WorkspaceChange::Init => {
+                state.update(WorkspaceChange::Create(id));
+            }
+            swayipc::WorkspaceChange::Empty => {
+                state.update(WorkspaceChange::Destroy(id));
+            }
+            swayipc::WorkspaceChange::Focus => {
+                state.update(WorkspaceChange::Focus(id));
+            }
+            // swayipc::WorkspaceChange::Urgent => todo!(),
+            _ => continue,
+        }
+        if let Ok(data) = serde_json::to_string(&state) {
+            println!("{}", data);
+        }
     }
     Ok(())
 }
+
 pub fn listen_and_print() {
     match _listen_and_print() {
-        Ok(_) => return,
+        Ok(_) => (),
         Err(e) => panic!("{}", e),
     }
 }


### PR DESCRIPTION
Also adds an internal workspace representation to be used for multiple window mangers.

This simplifies state updates & code maintenance. All while ensuring that the output is the same for all window managers.